### PR TITLE
Add material cutting feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ forgecore/
    For example, the inventory manager exposes a small CLI:
    ```bash
    python3 backend/inventory_manager/main.py list
+   # cut 40 inches from material id 1 and record the part
+   python3 backend/inventory_manager/main.py cut 1 40
    ```
 
 This scaffold is intentionally simple and is meant to serve as a base for advanced extensions such as AI-assisted optimizations and a production-ready UI.


### PR DESCRIPTION
## Summary
- add `cut_material` method for cutting inventory
- extend inventory CLI with a `cut` command
- document the new command in README

## Testing
- `python3 -m py_compile forgecore/backend/inventory_manager/main.py`

------
https://chatgpt.com/codex/tasks/task_e_68502eb1edb48324a667701def3b179d