### PR TITLE
Add WSL install and DB setup scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ forgecore/
 - MySQL server with access credentials
 - Python packages listed in `requirements.txt`
 
+## WSL Installation
+For a fresh Ubuntu WSL environment you can install Apache, MySQL, PHP and phpMyAdmin with:
+```bash
+./scripts/install_wsl.sh
+```
+This script also creates the `forgecore` database and user and links phpMyAdmin under `/phpmyadmin`.
+After installation load the database schema with:
+```bash
+php scripts/setup_database.php
+```
+
+
 ## Getting Started
 
 1. Set the following environment variables before running any module:

--- a/scripts/install_wsl.sh
+++ b/scripts/install_wsl.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+
+# Update package lists
+sudo apt-get update
+
+# Install Apache, MySQL, PHP, and phpMyAdmin
+sudo apt-get install -y apache2 mysql-server php libapache2-mod-php php-mysql phpmyadmin
+
+# Enable and start services
+sudo systemctl enable apache2
+sudo systemctl start apache2
+sudo systemctl enable mysql
+sudo systemctl start mysql
+
+# Basic MySQL setup
+DB_USER="forgecore"
+DB_PASS="forgecore"
+DB_NAME="forgecore"
+
+sudo mysql <<MYSQL
+CREATE DATABASE IF NOT EXISTS $DB_NAME;
+CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASS';
+GRANT ALL PRIVILEGES ON $DB_NAME.* TO '$DB_USER'@'localhost';
+FLUSH PRIVILEGES;
+MYSQL
+
+# Link phpMyAdmin to Apache document root
+if [ ! -e /var/www/html/phpmyadmin ]; then
+    sudo ln -s /usr/share/phpmyadmin /var/www/html/phpmyadmin
+fi
+
+echo "Installation complete. Access phpMyAdmin at http://localhost/phpmyadmin"

--- a/scripts/setup_database.php
+++ b/scripts/setup_database.php
@@ -1,0 +1,37 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'forgecore';
+$pass = getenv('DB_PASSWORD') ?: 'forgecore';
+$db   = getenv('DB_NAME') ?: 'forgecore';
+
+$mysqli = new mysqli($host, $user, $pass);
+if ($mysqli->connect_errno) {
+    fwrite(STDERR, "Connection failed: {$mysqli->connect_error}\n");
+    exit(1);
+}
+
+if (!$mysqli->query("CREATE DATABASE IF NOT EXISTS `$db`")) {
+    fwrite(STDERR, "Database creation failed: {$mysqli->error}\n");
+    exit(1);
+}
+$mysqli->select_db($db);
+
+$schema = file_get_contents(__DIR__ . '/../database/schema.sql');
+if ($schema === false) {
+    fwrite(STDERR, "Could not read schema file\n");
+    exit(1);
+}
+
+if ($mysqli->multi_query($schema)) {
+    do {
+        if ($result = $mysqli->store_result()) {
+            $result->free();
+        }
+    } while ($mysqli->more_results() && $mysqli->next_result());
+    echo "Database setup complete\n";
+} else {
+    fwrite(STDERR, "Error executing schema: {$mysqli->error}\n");
+    exit(1);
+}
+$mysqli->close();
+?>


### PR DESCRIPTION
## Summary
- add an install script for WSL that installs Apache, MySQL, PHP and phpMyAdmin
- add a PHP script to load the database schema
- document WSL installation instructions in the README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68503150c754832495763b5a1406ee6d