### PR TITLE
Add shop drawing request forms

### DIFF
--- a/forgecore/database/schema.sql
+++ b/forgecore/database/schema.sql
@@ -41,3 +41,16 @@ CREATE TABLE IF NOT EXISTS customers (
     address TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS shop_drawing_requests (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    job_number VARCHAR(255),
+    customer VARCHAR(255),
+    jobsite_address TEXT,
+    drawing_desc VARCHAR(255),
+    filename VARCHAR(255),
+    status VARCHAR(50) DEFAULT 'Pending',
+    notes TEXT,
+    title VARCHAR(255),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/forgecore/frontend/drawing_requests.php
+++ b/forgecore/frontend/drawing_requests.php
@@ -1,0 +1,62 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'forgecore';
+$pass = getenv('DB_PASSWORD') ?: '';
+$db   = getenv('DB_NAME') ?: 'forgecore';
+
+$mysqli = new mysqli($host, $user, $pass, $db);
+if ($mysqli->connect_errno) {
+    die('Connection failed: ' . $mysqli->connect_error);
+}
+
+$result = $mysqli->query('SELECT id, job_number, customer, jobsite_address, drawing_desc, filename, status, notes, title, created_at FROM shop_drawing_requests ORDER BY created_at DESC');
+$rows = $result ? $result->fetch_all(MYSQLI_ASSOC) : [];
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Shop Drawing Requests</title>
+    <style>
+        table { border-collapse: collapse; }
+        th, td { border: 1px solid #ccc; padding: 4px; }
+    </style>
+</head>
+<body>
+    <h1>Shop Drawing Requests</h1>
+    <table>
+        <tr>
+            <th>ID</th>
+            <th>Job Number</th>
+            <th>Customer</th>
+            <th>Jobsite Address</th>
+            <th>Title</th>
+            <th>Description</th>
+            <th>File</th>
+            <th>Status</th>
+            <th>Notes</th>
+            <th>Created</th>
+        </tr>
+        <?php foreach ($rows as $row): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($row['id']); ?></td>
+                <td><?php echo htmlspecialchars($row['job_number']); ?></td>
+                <td><?php echo htmlspecialchars($row['customer']); ?></td>
+                <td><?php echo nl2br(htmlspecialchars($row['jobsite_address'])); ?></td>
+                <td><?php echo htmlspecialchars($row['title']); ?></td>
+                <td><?php echo htmlspecialchars($row['drawing_desc']); ?></td>
+                <td>
+                    <?php if ($row['filename']): ?>
+                        <a href="uploads/<?php echo urlencode($row['filename']); ?>">Download</a>
+                    <?php endif; ?>
+                </td>
+                <td><?php echo htmlspecialchars($row['status']); ?></td>
+                <td><?php echo nl2br(htmlspecialchars($row['notes'])); ?></td>
+                <td><?php echo htmlspecialchars($row['created_at']); ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <p><a href="shop_drawing_request_form.php">Submit New Request</a></p>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/forgecore/frontend/index.php
+++ b/forgecore/frontend/index.php
@@ -9,6 +9,8 @@
     <p>This is a placeholder for the future web interface.</p>
     <ul>
         <li><a href="customer_form.php">Add Customer</a></li>
+        <li><a href="shop_drawing_request_form.php">New Shop Drawing Request</a></li>
+        <li><a href="drawing_requests.php">View Shop Drawing Requests</a></li>
     </ul>
 </body>
 </html>

--- a/forgecore/frontend/shop_drawing_request_form.php
+++ b/forgecore/frontend/shop_drawing_request_form.php
@@ -1,0 +1,95 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'forgecore';
+$pass = getenv('DB_PASSWORD') ?: '';
+$db   = getenv('DB_NAME') ?: 'forgecore';
+
+$mysqli = new mysqli($host, $user, $pass, $db);
+if ($mysqli->connect_errno) {
+    die('Connection failed: ' . $mysqli->connect_error);
+}
+
+$success = false;
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $job_number = trim($_POST['job_number'] ?? '');
+    $customer = trim($_POST['customer'] ?? '');
+    $jobsite_address = trim($_POST['jobsite_address'] ?? '');
+    $drawing_desc = trim($_POST['drawing_desc'] ?? '');
+    $status = trim($_POST['status'] ?? 'Pending');
+    $notes = trim($_POST['notes'] ?? '');
+    $title = trim($_POST['title'] ?? '');
+
+    $filename = null;
+    if (!empty($_FILES['file']['name'])) {
+        $upload_dir = __DIR__ . '/uploads/';
+        if (!is_dir($upload_dir)) {
+            mkdir($upload_dir, 0777, true);
+        }
+        $basename = basename($_FILES['file']['name']);
+        $target = $upload_dir . time() . '_' . preg_replace('/[^A-Za-z0-9._-]/', '_', $basename);
+        if (move_uploaded_file($_FILES['file']['tmp_name'], $target)) {
+            $filename = basename($target);
+        } else {
+            $error = 'File upload failed';
+        }
+    }
+
+    if ($error === '') {
+        $stmt = $mysqli->prepare('INSERT INTO shop_drawing_requests (job_number, customer, jobsite_address, drawing_desc, filename, status, notes, title) VALUES (?,?,?,?,?,?,?,?)');
+        if ($stmt) {
+            $stmt->bind_param('ssssssss', $job_number, $customer, $jobsite_address, $drawing_desc, $filename, $status, $notes, $title);
+            if ($stmt->execute()) {
+                $success = true;
+            } else {
+                $error = 'Insert failed: ' . $stmt->error;
+            }
+            $stmt->close();
+        } else {
+            $error = 'Prepare failed: ' . $mysqli->error;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Shop Drawing Request</title>
+</head>
+<body>
+    <h1>Shop Drawing Request</h1>
+    <?php if ($success): ?>
+        <p style="color:green;">Request submitted successfully.</p>
+    <?php elseif ($error !== ''): ?>
+        <p style="color:red;"><?php echo htmlspecialchars($error); ?></p>
+    <?php endif; ?>
+    <form method="post" action="" enctype="multipart/form-data">
+        <label>Job Number: <input type="text" name="job_number" required></label><br>
+        <label>Customer: <input type="text" name="customer" required></label><br>
+        <label>Jobsite Address:<br><textarea name="jobsite_address" rows="3" cols="40"></textarea></label><br>
+        <label>Title: <input type="text" name="title"></label><br>
+        <label>Drawing Description:
+            <select name="drawing_desc">
+                <option value="Plan">Plan</option>
+                <option value="Section">Section</option>
+                <option value="Detail">Detail</option>
+                <option value="Elevation">Elevation</option>
+                <option value="Other">Other</option>
+            </select>
+        </label><br>
+        <label>File Attachment: <input type="file" name="file"></label><br>
+        <label>Status:
+            <select name="status">
+                <option value="Pending">Pending</option>
+                <option value="In Review">In Review</option>
+                <option value="Completed">Completed</option>
+            </select>
+        </label><br>
+        <label>Notes:<br><textarea name="notes" rows="4" cols="40"></textarea></label><br>
+        <input type="submit" value="Submit Request">
+    </form>
+    <p><a href="drawing_requests.php">View Requests</a></p>
+    <p><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- extend schema with `shop_drawing_requests` table
- add frontend pages to submit and view shop drawing requests
- keep uploads directory for attachments
- link new pages from dashboard

## Testing
- `php -l forgecore/frontend/shop_drawing_request_form.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d8c82aec83249050526b360dbd79