### PR TITLE
Add drawing submittal form

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ php scripts/setup_database.php
    python3 backend/customer_manager/main.py list
    ```
 
-   A basic PHP form for adding customers is available at `frontend/customer_form.php`.
+  A basic PHP form for adding customers is available at `frontend/customer_form.php`.
+  A drawing submittal form is available at `frontend/drawing_submittal_form.php`.
 
 This scaffold is intentionally simple and is meant to serve as a base for advanced extensions such as AI-assisted optimizations and a production-ready UI.

--- a/forgecore/database/schema.sql
+++ b/forgecore/database/schema.sql
@@ -41,3 +41,13 @@ CREATE TABLE IF NOT EXISTS customers (
     address TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS drawing_submittals (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    drawing_number VARCHAR(255) NOT NULL,
+    job_number VARCHAR(255) NOT NULL,
+    description TEXT,
+    submitted_by VARCHAR(255) NOT NULL,
+    submission_date DATE DEFAULT CURRENT_DATE,
+    status ENUM('Submitted','Reviewed','Approved') DEFAULT 'Submitted'
+);

--- a/forgecore/frontend/drawing_submittal_form.php
+++ b/forgecore/frontend/drawing_submittal_form.php
@@ -1,0 +1,95 @@
+<?php
+$host = getenv('DB_HOST') ?: 'localhost';
+$user = getenv('DB_USER') ?: 'forgecore';
+$pass = getenv('DB_PASSWORD') ?: '';
+$db   = getenv('DB_NAME') ?: 'forgecore';
+
+$mysqli = new mysqli($host, $user, $pass, $db);
+if ($mysqli->connect_errno) {
+    die('Connection failed: ' . $mysqli->connect_error);
+}
+
+$success = false;
+$error = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $drawing_number = trim($_POST['drawing_number'] ?? '');
+    $job_number = trim($_POST['job_number'] ?? '');
+    $description = trim($_POST['description'] ?? '');
+    $submitted_by = trim($_POST['submitted_by'] ?? '');
+    $submission_date = trim($_POST['submission_date'] ?? '');
+    $status = trim($_POST['status'] ?? 'Submitted');
+
+    // Basic validation
+    if ($drawing_number === '' || $job_number === '' || $submitted_by === '') {
+        $error = 'Drawing number, job number and submitted by are required.';
+    } elseif ($status !== 'Submitted' && $status !== 'Reviewed' && $status !== 'Approved') {
+        $error = 'Invalid status value.';
+    } else {
+        if ($submission_date === '') {
+            $submission_date = date('Y-m-d');
+        }
+        // Use prepared statement
+        $stmt = $mysqli->prepare('INSERT INTO drawing_submittals (drawing_number, job_number, description, submitted_by, submission_date, status) VALUES (?, ?, ?, ?, ?, ?)');
+        if ($stmt) {
+            $stmt->bind_param('ssssss', $drawing_number, $job_number, $description, $submitted_by, $submission_date, $status);
+            if ($stmt->execute()) {
+                $success = true;
+            } else {
+                $error = 'Insert failed: ' . $stmt->error;
+            }
+            $stmt->close();
+        } else {
+            $error = 'Prepare failed: ' . $mysqli->error;
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Drawing Submittal</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+</head>
+<body class="container py-4">
+    <h1>Drawing Submittal Form</h1>
+    <?php if ($success): ?>
+        <div class="alert alert-success">Drawing submitted successfully.</div>
+    <?php elseif ($error !== ''): ?>
+        <div class="alert alert-danger"><?php echo htmlspecialchars($error); ?></div>
+    <?php endif; ?>
+    <form method="post" action="" class="mt-3">
+        <div class="mb-3">
+            <label class="form-label">Drawing Number</label>
+            <input type="text" name="drawing_number" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Job Number</label>
+            <input type="text" name="job_number" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Description</label>
+            <textarea name="description" class="form-control" rows="3"></textarea>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Submitted By</label>
+            <input type="text" name="submitted_by" class="form-control" required>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Submission Date</label>
+            <input type="date" name="submission_date" class="form-control">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Status</label>
+            <select name="status" class="form-select">
+                <option value="Submitted">Submitted</option>
+                <option value="Reviewed">Reviewed</option>
+                <option value="Approved">Approved</option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-primary">Submit</button>
+    </form>
+    <p class="mt-3"><a href="index.php">Back to Dashboard</a></p>
+</body>
+</html>

--- a/forgecore/frontend/index.php
+++ b/forgecore/frontend/index.php
@@ -9,6 +9,7 @@
     <p>This is a placeholder for the future web interface.</p>
     <ul>
         <li><a href="customer_form.php">Add Customer</a></li>
+        <li><a href="drawing_submittal_form.php">Submit Drawing</a></li>
     </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add drawing submittal form with Bootstrap styling and DB insert logic
- create `drawing_submittals` table in schema
- link new page from dashboard
- mention form in README

## Testing
- `php -l forgecore/frontend/drawing_submittal_form.php`
- `php -l forgecore/frontend/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6851d958318883248fd68bdb7b0ad9d2