### PR TITLE
Implement drawing submittal logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ php scripts/setup_database.php
    python3 backend/customer_manager/main.py list
    ```
 
+  Drawing submittals can also be logged from the CLI:
+  ```bash
+  python3 backend/drawing_submittal_logger/main.py add 1234 J100 Alice
+  python3 backend/drawing_submittal_logger/main.py list
+  ```
+
   A basic PHP form for adding customers is available at `frontend/customer_form.php`.
   A drawing submittal form is available at `frontend/drawing_submittal_form.php`.
 

--- a/forgecore/backend/drawing_submittal_logger/main.py
+++ b/forgecore/backend/drawing_submittal_logger/main.py
@@ -1,0 +1,87 @@
+"""Command line utilities for logging drawing submittals."""
+from __future__ import annotations
+
+import argparse
+import datetime
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[2] / "config"))
+
+from config import config
+
+
+def dict_cursor(conn):
+    return conn.cursor(dictionary=True)
+
+
+class DrawingSubmittalLogger:
+    def __init__(self) -> None:
+        self.conn = config.get_connection()
+
+    def list_submittals(self):
+        cur = dict_cursor(self.conn)
+        cur.execute(
+            "SELECT id, drawing_number, job_number, description, submitted_by, submission_date, status, created_at "
+            "FROM drawing_submittals ORDER BY submission_date DESC"
+        )
+        rows = cur.fetchall()
+        cur.close()
+        return rows
+
+    def log_submittal(
+        self,
+        drawing_number: str,
+        job_number: str,
+        submitted_by: str,
+        description: str | None = None,
+        submission_date: str | None = None,
+        status: str = "Submitted",
+    ) -> int:
+        date_val = submission_date or datetime.date.today().isoformat()
+        cur = self.conn.cursor()
+        cur.execute(
+            "INSERT INTO drawing_submittals (drawing_number, job_number, description, submitted_by, submission_date, status) "
+            "VALUES (%s,%s,%s,%s,%s,%s)",
+            (drawing_number, job_number, description, submitted_by, date_val, status),
+        )
+        self.conn.commit()
+        new_id = cur.lastrowid
+        cur.close()
+        return new_id
+
+
+def cli() -> None:
+    parser = argparse.ArgumentParser(description="Log drawing submittals")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    sub.add_parser("list", help="List drawing submittals")
+
+    add_p = sub.add_parser("add", help="Record a new drawing submittal")
+    add_p.add_argument("drawing_number")
+    add_p.add_argument("job_number")
+    add_p.add_argument("submitted_by")
+    add_p.add_argument("--description", default=None)
+    add_p.add_argument("--date", default=None, help="Submission date YYYY-MM-DD")
+    add_p.add_argument("--status", default="Submitted")
+
+    args = parser.parse_args()
+    dsl = DrawingSubmittalLogger()
+
+    if args.cmd == "list":
+        for row in dsl.list_submittals():
+            print(row)
+    elif args.cmd == "add":
+        sid = dsl.log_submittal(
+            args.drawing_number,
+            args.job_number,
+            args.submitted_by,
+            description=args.description,
+            submission_date=args.date,
+            status=args.status,
+        )
+        print(f"Recorded submittal {sid}")
+
+
+if __name__ == "__main__":
+    cli()

--- a/forgecore/database/schema.sql
+++ b/forgecore/database/schema.sql
@@ -41,3 +41,14 @@ CREATE TABLE IF NOT EXISTS customers (
     address TEXT,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
+
+CREATE TABLE IF NOT EXISTS drawing_submittals (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    drawing_number VARCHAR(255) NOT NULL,
+    job_number VARCHAR(255) NOT NULL,
+    description TEXT,
+    submitted_by VARCHAR(255) NOT NULL,
+    submission_date DATE DEFAULT CURRENT_DATE,
+    status ENUM('Submitted','Reviewed','Approved') DEFAULT 'Submitted',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/forgecore/frontend/index.php
+++ b/forgecore/frontend/index.php
@@ -9,6 +9,7 @@
     <p>This is a placeholder for the future web interface.</p>
     <ul>
         <li><a href="customer_form.php">Add Customer</a></li>
+        <li><a href="drawing_submittal_form.php">Submit Drawing</a></li>
     </ul>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add drawing_submittal_logger backend module
- restore drawing_submittals table to schema
- provide CLI usage example in README
- link drawing submittal form from dashboard

## Testing
- `python3 -m py_compile forgecore/backend/drawing_submittal_logger/main.py`
- `php -l forgecore/frontend/index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e1410d8c83248b5f3732b0cc23ca