### PR TITLE
Add Docker stack for ForgeCore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM php:8.1-apache
+
+# Install Python and pip
+RUN apt-get update \
+    && apt-get install -y python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install php extensions for MySQL
+RUN docker-php-ext-install mysqli pdo_mysql
+
+# Copy application code
+COPY . /opt/forgecore
+
+# Install Python requirements
+RUN pip3 install --no-cache-dir -r /opt/forgecore/requirements.txt
+
+# Link PHP frontend to Apache document root
+RUN rm -rf /var/www/html && ln -s /opt/forgecore/forgecore/frontend /var/www/html
+
+WORKDIR /opt/forgecore
+
+# Default environment values; can be overridden in docker-compose
+ENV DB_HOST=db
+ENV DB_USER=forgecore
+ENV DB_PASSWORD=forgecore
+ENV DB_NAME=forgecore
+
+# Expose Apache port
+EXPOSE 80
+
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -58,5 +58,18 @@ forgecore/
 
 For a turnkey Windows Subsystem for Linux setup see `scripts/install_wsl.sh`.
 
+## Docker
+To run the entire stack in containers, install Docker and execute:
+```bash
+docker-compose up -d
+```
+This starts the application, MySQL and phpMyAdmin. The default database credentials are:
+- Host: `db`
+- User: `forgecore`
+- Password: `forgecore`
+- Database: `forgecore`
+phpMyAdmin is available on port 8080 and the PHP frontend on port 8000.
+
+
 ## License
 This repository is released under the MIT license.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.8"
+
+services:
+  db:
+    image: mysql:8.0
+    environment:
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_DATABASE: forgecore
+      MYSQL_USER: forgecore
+      MYSQL_PASSWORD: forgecore
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./forgecore/database/schema.sql:/docker-entrypoint-initdb.d/schema.sql:ro
+    ports:
+      - "3306:3306"
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin
+    environment:
+      PMA_HOST: db
+      MYSQL_ROOT_PASSWORD: rootpass
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+
+  app:
+    build: .
+    ports:
+      - "8000:80"
+    environment:
+      DB_HOST: db
+      DB_USER: forgecore
+      DB_PASSWORD: forgecore
+      DB_NAME: forgecore
+    depends_on:
+      - db
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add Dockerfile with PHP/Apache and Python
- add docker-compose to launch MySQL, phpMyAdmin and the app
- document container usage and default credentials in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- ❌ `docker-compose --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859568a66048324b975cc0b199bf542