### PR TITLE
Add install script and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,17 +41,18 @@ forgecore/
 - Packages listed in `requirements.txt`
 
 ## Quick Start
-1. Install the requirements:
+1. Execute the install script which installs the Python requirements and
+   initializes a local MySQL database:
    ```bash
-   pip install -r requirements.txt
+   ./scripts/install.sh
    ```
-2. Import `forgecore/database/schema.sql` into MySQL.
-3. Export the database credentials expected by `forgecore/config/config.py`:
+   The script prints the database credentials it configured. Export these
+   values so the backend modules can locate the database:
    - `DB_HOST`
    - `DB_USER`
    - `DB_PASSWORD`
    - `DB_NAME`
-4. Run a module to verify connectivity, for example:
+2. Run a module to verify connectivity, for example:
    ```bash
    python3 forgecore/backend/inventory_manager/main.py list
    ```

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# ForgeCore installation script
+# Installs Python requirements and initializes MySQL database
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+DB_USER="${DB_USER:-forgecore}"
+DB_PASSWORD="${DB_PASSWORD:-forgecore}"
+DB_NAME="${DB_NAME:-forgecore}"
+DB_HOST="${DB_HOST:-localhost}"
+MYSQL_ROOT_USER="${MYSQL_ROOT_USER:-root}"
+MYSQL_ROOT_PASS="${MYSQL_ROOT_PASS:-}"
+
+echo "[1/3] Installing Python packages"
+pip3 install --user -r "$ROOT_DIR/requirements.txt"
+
+if ! command -v mysql >/dev/null; then
+    echo "MySQL client not found. Please install MySQL server and rerun." >&2
+    exit 1
+fi
+
+echo "[2/3] Configuring MySQL database"
+mysql -u "$MYSQL_ROOT_USER" ${MYSQL_ROOT_PASS:+-p"$MYSQL_ROOT_PASS"} <<SQL
+CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`;
+CREATE USER IF NOT EXISTS '$DB_USER'@'localhost' IDENTIFIED BY '$DB_PASSWORD';
+GRANT ALL PRIVILEGES ON \`$DB_NAME\`.* TO '$DB_USER'@'localhost';
+FLUSH PRIVILEGES;
+SQL
+
+mysql -u "$DB_USER" -p"$DB_PASSWORD" "$DB_NAME" < "$ROOT_DIR/forgecore/database/schema.sql"
+
+echo "[3/3] Setup complete"
+cat <<EOM
+
+Add the following to your shell profile (~/.bashrc or similar):
+export DB_HOST=$DB_HOST
+export DB_USER=$DB_USER
+export DB_PASSWORD=$DB_PASSWORD
+export DB_NAME=$DB_NAME
+EOM
+


### PR DESCRIPTION
## Summary
- add `scripts/install.sh` for one-step setup
- document usage of the install script in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `bash -n scripts/install.sh`
- `./scripts/install.sh` *(fails: MySQL client not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868b5b32c8083248d573826736b26b6